### PR TITLE
fix: show modal on invalid or unauthorized world deep links

### DIFF
--- a/components/modals/AccessDeniedModal.tsx
+++ b/components/modals/AccessDeniedModal.tsx
@@ -1,0 +1,19 @@
+import { AppModal, Button } from '@/components/ui';
+
+interface AccessDeniedModalProps {
+  visible: boolean;
+  onClose: () => void;
+}
+
+export function AccessDeniedModal({ visible, onClose }: AccessDeniedModalProps) {
+  return (
+    <AppModal
+      visible={visible}
+      onClose={onClose}
+      heading="You ventured down the wrong path"
+      body="We do not see that you have access to this world. You can go to settings to refresh your data, or ask the DM for a new invite."
+    >
+      <Button text="Continue" variant="secondary" onPress={onClose} />
+    </AppModal>
+  );
+}


### PR DESCRIPTION
## Summary
Improves deep link UX by detecting invalid/unauthorized world URLs, redirecting users to a safe screen, and showing a clear modal explaining why the link couldn’t be opened.

## Changes
- Adds centralized handling for bad world deep links (invalid worldId, no access, expired invite, etc.)
- Redirects to `/select/world-selection` when a world link cannot be resolved
- Displays a modal message (e.g., “Invalid or inaccessible world link”) with a dismiss action
- Ensures the behavior lives in the routing/guard layer (not duplicated per screen)

### Notes
- Focused on clarity and trust: avoids “silent failure” redirects
- Designed to be extensible for future actions (e.g., Request Access) without expanding scope now
